### PR TITLE
added corrator to the list of dockertools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 
-
 ![stars](https://img.shields.io/github/stars/collabnix/dockertools)
 ![forks](https://img.shields.io/github/forks/collabnix/dockertools)
 ![issues](https://img.shields.io/github/issues/collabnix/dockertools)
@@ -22,7 +21,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 <img width="1072" alt="image" src="https://user-images.githubusercontent.com/34368930/169660363-17e48331-660b-4f87-acd6-eaea195f25fe.png">
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 | 1 | docker build  | [Easily create and share portable Docker container images using open standards](https://docs.docker.com/engine/reference/commandline/build/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs) |
 | 2 | docker buildx | [Extended build capabilities with Buildkit](https://docs.docker.com/engine/reference/commandline/buildx/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs) |
@@ -37,7 +36,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Open Source Developer Tools
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 | 1 | DockerSlim| [Minify and Secure Docker containers](https://github.com/docker-slim/docker-slim)     | ![Github Stars](https://img.shields.io/github/stars/docker-slim/docker-slim)   |
 |   2   | Minicon | [Minimization of the filesystem for containers](https://github.com/grycap/minicon) |![Github Stars](https://img.shields.io/github/stars/grycap/minicon) |
@@ -62,7 +61,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Image Build Toolkit
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 | 1 | BuildKit | [Toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner](https://github.com/moby/buildkit) |![stars](https://img.shields.io/github/stars/moby/buildkit)  |
 | 2 |  Dive |[Tool for exploring each layer in a docker image](https://github.com/wagoodman/dive)  |![stars](https://img.shields.io/github/stars/wagoodman/dive)
@@ -79,19 +78,19 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Image Utilties
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Bing Daily Images -|[A docker container that downloads bing daily images for you](https://github.com/ms-jpq/bing-daily-images) | ![stars](https://img.shields.io/github/stars/ms-jpq/bing-daily-images)|
 
 ## Testing Tools
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
-|1| Kurtosis| - [Kurtosis is a composable build system for reproducible test environments](https://github.com/kurtosis-tech/kurtosis#readmev)![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) ![Twitter](https://img.shields.io/twitter/follow/kurtosis-tech?style=social)| ![stars](https://img.shields.io/github/stars/kurtosis-tech/kurtosis) |
+|1| Kurtosis - [Kurtosis is a composable build system for reproducible test environments](https://github.com/kurtosis-tech/kurtosis#readmev)| ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) ![Twitter](https://img.shields.io/twitter/follow/kurtosis-tech?style=social)| ![stars](https://img.shields.io/github/stars/kurtosis-tech/kurtosis)|
 
 ## Dockerfile Tools & Metrics
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Haskell Dockerfile Linter| [Dockerfile linter, validate inline bash, written in Haskell](https://github.com/hadolint/hadolint) |![stars](https://img.shields.io/github/stars/hadolint/hadolint)|
 |2| ctop | [Top-like interface for container metrics](https://github.com/bcicen/ctop) | ![stars](https://img.shields.io/github/stars/bcicen/ctop)|
@@ -101,14 +100,14 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Debugger
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Gebug | [A tool that makes debugging of Dockerized Go applications super easy by enabling Debugger and Hot-Reload features, seamlessly](https://github.com/moshebe/gebug) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) |![stars](https://img.shields.io/github/stars/moshebe/gebug)|
 |2| Sidekick | [Sidekick is a live application debugger that lets you troubleshoot your applications while they keep on running.](https://github.com/runsidekick/sidekick) |![stars](https://img.shields.io/github/stars/runsidekick/sidekick) |
 
 ## Image Security
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| TerraScan | [Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure](https://github.com/accurics/terrascan)  |![stars](https://img.shields.io/github/stars/accurics/terrascan)|
 |2| Clair | [Vulnerability Static Analysis for Containers](https://github.com/quay/clair) |![stars](https://img.shields.io/github/stars/quay/clair) |
@@ -121,7 +120,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Docker CLI
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Docker Buildx | [A CLI plugin that extends the docker command with the full support of the features provided by Moby BuildKit builder toolkit.](https://docs.docker.com/buildx/working-with-buildx/) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564)|![stars](https://img.shields.io/github/stars/docker/docs) |
 |2| Regi | [Regi is a CLI tool for managing your accessibility to multiple Docker registries.](https://github.com/iamharvey/regi) |![stars](https://img.shields.io/github/stars/iamharvey/regi)|
@@ -131,13 +130,13 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## DockerHub
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1|  DockerHub Scraper | [Scraping DockerHub](https://github.com/itamarhaber/dockerhub-scraper) |![stars](https://img.shields.io/github/stars/itamarhaber/dockerhub-scraper) |
 
 ## Deployment Tool
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Fleetform | [A tool to apply docker container infrastructure as code in a very simple human readable way](https://github.com/majo418/fleetform) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) |![stars](https://img.shields.io/github/stars/majo418/fleetform)|
 |2| Swarmsible |[Simple Ansible based Tooling for setting up and managing a production grade Docker Swarm on Ubuntu 18.04/20.04.](https://github.com/neuroforgede/swarmsible) |![stars](https://img.shields.io/github/stars/neuroforgede/swarmsible)|
@@ -147,20 +146,20 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Docker Volume
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Flocker | [Data Volume Manager for your Dockerized applications.](https://github.com/ClusterHQ/flocker)| ![stars](https://img.shields.io/github/stars/clusterhq/flocker)|
 |2| offen/docker-volume-backup | [Backup Docker volumes locally or to any S3 or WebDAV compatible storage](https://github.com/offen/docker-volume-backup)|![stars](https://img.shields.io/github/stars/offen/docker-volume-backup)|
 
 ## Cloud-Job
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Launcha | [Launcha is a docker-based cloud job launcher.](https://github.com/vwxyzjn/launcha)|![stars](https://img.shields.io/github/stars/vwxyzjn/launcha)|
 
 ## Runtime Security
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1|Tracee | [Linux Runtime Security and Forensics using eBPF](https://github.com/aquasecurity/tracee) | ![stars](https://img.shields.io/github/stars/tracee)|
 |2| CetusGuard | [Tool that allows to protect the Docker daemon socket by filtering the calls to its API endpoints](https://github.com/hectorm/cetusguard)| ![stars](https://img.shields.io/github/stars/hectorm/cetusguard)|
@@ -169,7 +168,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Container Orchestration
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Miniboss | [Manages container locally](https://github.com/afroisalreadyinu/miniboss)| ![GitHub Stars](https://img.shields.io/github/stars/afroisalreadyinu/miniboss)|
 |2| Portainer | [Making Docker management easy. https://www.portainer.io](https://github.com/portainer/portainer)|![Docker Pulls](https://img.shields.io/docker/pulls/portainer/portainer) ![GitHub Stars](https://img.shields.io/github/stars/portainer/portainer) |
@@ -183,7 +182,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Browser
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| kde-in-docker | [Run KDE inside a browser](https://github.com/ms-jpq/kde-in-docker) |![GitHub Stars](https://img.shields.io/github/stars/ms-jpq/kde-in-docker) |
 |2|  Portus | [3D Docker containers viewer built with Electron, React and Three Fiber](https://github.com/trindadematheus/portus)| ![GitHub Stars](https://img.shields.io/github/stars/trindadematheus/portus) <br>
@@ -191,25 +190,25 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Cluster Management
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Nebula | [Designed to manage massive clusters at scale.](http://nebula.readthedocs.io/en/latest/)|![GitHub Stars](https://img.shields.io/github/stars/nebula-orchestrator/docs) |
 
 ## Machine Learning
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Paddle Serving | [A flexible, high-performance carrier for machine learning models](https://github.com/PaddlePaddle/Serving) |![GitHub Stars](https://img.shields.io/github/stars/PaddlePaddle/Serving)|
 
 ## Android app
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Android-Docker | [A Docker image for building and testing Android apps.](https://github.com/randr0id/android-docker) |![GitHub Stars](https://img.shields.io/github/stars/randr0id/android-docker) |
 
 ## Development Tool
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| envd | [Development environment for AI/ML based on buildkit](https://github.com/tensorchord/envd) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564)| ![GitHub Stars](https://img.shields.io/github/stars/tensorchord/envd) |
 |2| Konveyor Move2Kube | [Automatically create Dockerfiles, Kubernetes Yamls, Helm charts and other Infrastructure as Code Artifacts for your application.](https://move2kube.konveyor.io/)| ![GitHub Stars](https://img.shields.io/github/stars/konveyor/move2kube-operator) |
@@ -221,13 +220,13 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Workflow
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| An open source, general-purpose policy engine. | [A Docker-inspired workflow for OPA policies](https://www.openpolicyagent.org/)|![stars](https://img.shields.io/github/stars/open-policy-agent/opa)|
 
 ## Networking
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Project Calico | [Docker libnetwork plugin for Calico http://www.projectcalico.org](https://github.com/projectcalico/calico)| ![stars](https://img.shields.io/github/stars/projectcalico/calico) |
 |2| Libnetwork | [Networking for containers](https://github.com/moby/libnetwork)|![stars](https://img.shields.io/github/stars/moby/libnetwork)|
@@ -235,7 +234,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Swarm
 
-| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Orbiter | [Autoscaler for Docker Swarm](https://github.com/gianarb/orbiter)| ![stars](https://img.shields.io/github/stars/gianarb/orbiter)|
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 
 ## Image Slim
+
 |	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
 |	1	| DockerSlim| [Minify and Secure Docker containers](https://github.com/docker-slim/docker-slim)     | ![Github Stars](https://img.shields.io/github/stars/docker-slim/docker-slim)   |
@@ -70,6 +71,7 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |18| Openresty|[Docker tooling for OpenResty](https://hub.docker.com/r/openresty/openresty) |![Github Stars](https://img.shields.io/github/stars/openresty/docker-openresty) |
 |19| Oxker|[A simple gui to view & control docker containers.](https://github.com/mrjackwills/oxker) |![Github Stars](https://img.shields.io/github/stars/mrjackwills/oxker) |
 |20| Dockerdot|[dockerdot shows dockerfile dependenciy graph. This is useful to understand how build dockerfile. This uses Go WebAssembly + BuildKit package..](https://github.com/po3rin/dockerdot) |![Github Stars](https://img.shields.io/github/stars/po3rin/dockerdot) |
+|21| Corrator|[A tool to verify the versions of apps used inside docker containers.](https://github.com/natecox/corrator) |![Github Stars](https://img.shields.io/github/stars/natecox/corrator) |
 
 
 ## Image Build Toolkit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 
-
-
-
 ![stars](https://img.shields.io/github/stars/collabnix/dockertools)
 ![forks](https://img.shields.io/github/forks/collabnix/dockertools)
 ![issues](https://img.shields.io/github/issues/collabnix/dockertools)
@@ -9,56 +6,46 @@
 ![Visitor count](https://shields-io-visitor-counter.herokuapp.com/badge?page=collabnix.dockertools)
 ![Twitter](https://img.shields.io/twitter/follow/collabnix?style=social)
 
-Developers love Docker. Docker is a suite of software development tools for creating, sharing and running containers. Developers use Docker to accelerate how they build, share, and run modern applications. This repository was built with a purpose. It is being used by Collabnix community internally to target the most popular developer tools and technique and coming up with the best practices around these tools. 
-
+Developers love Docker. Docker is a suite of software development tools for creating, sharing and running containers. Developers use Docker to accelerate how they build, share, and run modern applications. This repository was built with a purpose. It is being used by Collabnix community internally to target the most popular developer tools and technique and coming up with the best practices around these tools.
 
 Follow [the Collabnix Twitter account](https://twitter.com/collabnix) to keep track of the latest developer tools.
 
 Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get chance to be a part of 6700+ DevOps enthusiasts.<br>
 
-
 # Types of Docker Developer Tools
 
 - [Docker Integrated Developer Tools](https://github.com/collabnix/dockertools#docker-integrated-developer-tools)
 - [Open Source Developer Tools](https://github.com/collabnix/dockertools#open-source-developer-tools)
-- 
 
 ## Docker Integrated Developer Tools
 
 <img width="1072" alt="image" src="https://user-images.githubusercontent.com/34368930/169660363-17e48331-660b-4f87-acd6-eaea195f25fe.png">
 
-
-
-| Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
-|	1	|	docker build 	|	[Easily create and share portable Docker container images using open standards](https://docs.docker.com/engine/reference/commandline/build/)	|	![Github Stars](https://img.shields.io/github/stars/docker/docs)	|
-|	2	|	docker buildx	|	[Extended build capabilities with Buildkit](https://docs.docker.com/engine/reference/commandline/buildx/)	|	![Github Stars](https://img.shields.io/github/stars/docker/docs)	|
-|	3	|	docker compose	| [Build and Manage multiple services in Docker containers](https://docs.docker.com/engine/reference/commandline/compose/)|	![Github Stars](https://img.shields.io/github/stars/docker/docs)|
-| 4|docker scan	| [Quickly detect and learn how to remediate CVEs in your Docker image](https://docs.docker.com/engine/scan/)	|	![Github Stars](https://img.shields.io/github/stars/docker/docs)|
+| 1 | docker build  | [Easily create and share portable Docker container images using open standards](https://docs.docker.com/engine/reference/commandline/build/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs) |
+| 2 | docker buildx | [Extended build capabilities with Buildkit](https://docs.docker.com/engine/reference/commandline/buildx/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs) |
+| 3 | docker compose | [Build and Manage multiple services in Docker containers](https://docs.docker.com/engine/reference/commandline/compose/)| ![Github Stars](https://img.shields.io/github/stars/docker/docs)|
+| 4|docker scan | [Quickly detect and learn how to remediate CVEs in your Docker image](https://docs.docker.com/engine/scan/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs)|
 | 5| docker context ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) |  [Manages multiple Swarm clusters, Kubernetes clusters and Docker nodes](https://docs.docker.com/engine/context/working-with-contexts/) |![Github Stars](https://img.shields.io/github/stars/docker/docs) |
 | 6| docker sbom | [Generate the Software Bill of Materials (SBOM) of a container image](https://docs.docker.com/engine/sbom/) |![Github Stars](https://img.shields.io/github/stars/docker/docs) |
 | 7| docker extensions | [Use 3rd party tools within Docker Desktop to extend its functionality](https://docs.docker.com/desktop/extensions/) |![Github Stars](https://img.shields.io/github/stars/docker/docs) |
 | 8 | docker trust | [Manage trust on Docker Images](https://docs.docker.com/engine/reference/commandline/trust/) |![Github Stars](https://img.shields.io/github/stars/docker/docs) |
 | 9| docker dev | [Run Dev Envs via command line](https://docs.docker.com/desktop/release-notes/#new) |![Github Stars](https://img.shields.io/github/stars/docker/docs) |
-| 10 | docker scout |[ A Software Supply Chain Security for Developers](https://docs.docker.com/scout/) |![Github Stars](https://img.shields.io/github/stars/docker/docs) |
-
+| 10 | docker scout |[A Software Supply Chain Security for Developers](https://docs.docker.com/scout/) |![Github Stars](https://img.shields.io/github/stars/docker/docs) |
 
 ## Open Source Developer Tools
 
-
-
-## Image Slim
-
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
-|	1	| DockerSlim| [Minify and Secure Docker containers](https://github.com/docker-slim/docker-slim)     | ![Github Stars](https://img.shields.io/github/stars/docker-slim/docker-slim)   |
+| 1 | DockerSlim| [Minify and Secure Docker containers](https://github.com/docker-slim/docker-slim)     | ![Github Stars](https://img.shields.io/github/stars/docker-slim/docker-slim)   |
 |   2   | Minicon | [Minimization of the filesystem for containers](https://github.com/grycap/minicon) |![Github Stars](https://img.shields.io/github/stars/grycap/minicon) |
 | 3 |   Watchtower | [A process for automating Docker container base image updates](https://github.com/containrrr/watchtower) | ![Docker Pulls](https://img.shields.io/docker/pulls/containrrr/watchtower)  ![GitHub Stars](https://img.shields.io/github/stars/containrrr/watchtower) |
 |4 |Syft|[CLI tool and library for generating a Software Bill of Materials from container images and filesystems](https://github.com/anchore/syft) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564)| ![Docker Pulls](https://img.shields.io/docker/pulls/anchore/syft) ![Github stars](https://img.shields.io/github/stars/anchore/syft)|
-| 5| gitlab-ci-image-scanner (gcis) |[executes security scan over all Docker images used in all CI files ](https://github.com/jkosik/gitlab-ci-image-scanner)  ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) | ![Github Stars](https://img.shields.io/github/stars/jkosik/gitlab-ci-image-scanner) |
-|6  | Watchtower | [A process for automating Docker container base image updates](https://github.com/containrrr/watchtower) |![GitHub Stars](https://img.shields.io/github/stars/containrrr/watchtower) 
+| 5| gitlab-ci-image-scanner (gcis) |[executes security scan over all Docker images used in all CI files](https://github.com/jkosik/gitlab-ci-image-scanner)  ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) | ![Github Stars](https://img.shields.io/github/stars/jkosik/gitlab-ci-image-scanner) |
+|6  | Watchtower | [A process for automating Docker container base image updates](https://github.com/containrrr/watchtower) |![GitHub Stars](https://img.shields.io/github/stars/containrrr/watchtower)
 |7| dockcross |[Cross compiling toolchains in Docker images.](https://linktr.ee/dockcross) |![Github Stars](https://img.shields.io/github/stars/dockcross) |
-|8| fluentd |[collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on. Fluentd helps you unify your logging infrastructure ](https://www.fluentd.org/) |![Github Stars](https://img.shields.io/github/stars/fluent/fluentd) |
+|8| fluentd |[collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on. Fluentd helps you unify your logging infrastructure](https://www.fluentd.org/) |![Github Stars](https://img.shields.io/github/stars/fluent/fluentd) |
 |9| Logspout |[Logspout is a log router for Docker containers that runs inside Docker](https://github.com/gliderlabs/logspout#readme) |![Github Stars](https://img.shields.io/github/stars/gliderlabs/logspout) |
 |10| Packer |[Packer is an automated system that helps create images for containers and virtual machines. It is a lightweight application and works with most major operating systems.](https://github.com/hasahicorp/packer) |![Github Stars](https://img.shields.io/github/stars/hashicorp/packer) |
 |11| Flannel |[Flannel is a networking tool that helps connect multiple docker containers. It creates an overlay mesh network that resolves the issues faced when creating subnets.](https://github.com/flannel-io/flannel) |![Github Stars](https://img.shields.io/github/stars/flannel-io/flannel) |
@@ -71,17 +58,15 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |18| Openresty|[Docker tooling for OpenResty](https://hub.docker.com/r/openresty/openresty) |![Github Stars](https://img.shields.io/github/stars/openresty/docker-openresty) |
 |19| Oxker|[A simple gui to view & control docker containers.](https://github.com/mrjackwills/oxker) |![Github Stars](https://img.shields.io/github/stars/mrjackwills/oxker) |
 |20| Dockerdot|[dockerdot shows dockerfile dependenciy graph. This is useful to understand how build dockerfile. This uses Go WebAssembly + BuildKit package..](https://github.com/po3rin/dockerdot) |![Github Stars](https://img.shields.io/github/stars/po3rin/dockerdot) |
-|21| Corrator|[A tool to verify the versions of apps used inside docker containers.](https://github.com/natecox/corrator) |![Github Stars](https://img.shields.io/github/stars/natecox/corrator) |
-
 
 ## Image Build Toolkit
 
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
-|	1	| BuildKit | [Toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner](https://github.com/moby/buildkit) |![stars](https://img.shields.io/github/stars/moby/buildkit)  |
-| 2 |  Dive |[Tool for exploring each layer in a docker image](https://github.com/wagoodman/dive)  |![stars](https://img.shields.io/github/stars/wagoodman/dive) 
+| 1 | BuildKit | [Toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner](https://github.com/moby/buildkit) |![stars](https://img.shields.io/github/stars/moby/buildkit)  |
+| 2 |  Dive |[Tool for exploring each layer in a docker image](https://github.com/wagoodman/dive)  |![stars](https://img.shields.io/github/stars/wagoodman/dive)
 |3 |  Docker-Squash | [Squashing helps with organizing images in logical layers.](https://github.com/goldmann/docker-squash) |![stars](https://img.shields.io/github/stars/goldmann/docker-squash)|
-|4|  Docker-Diun |[ Docker image update notifier](https://github.com/crazy-max/diun) |![stars](https://img.shields.io/github/stars/crazy-max/diun) |
+|4|  Docker-Diun |[Docker image update notifier](https://github.com/crazy-max/diun) |![stars](https://img.shields.io/github/stars/crazy-max/diun) |
 |5| Trivy |[Trivy is a container image scanner which uncovers known vulnerabilities.](https://www.cloudsavvyit.com/12027/how-to-use-trivy-to-find-vulnerabilities-in-docker-containers) |![stars](https://img.shields.io/github/stars/goldmann/docker-squash) |
 |6| vbaksa/promoter | [Docker Image promotion tool](https://github.com/vbaksa/promoter) |![stars](https://img.shields.io/github/stars/vbaksa/promoter)
 |7| Argo Watcher |[A small tool that will wait for the specific docker image to be rolled out](https://github.com/shini4i/argo-watcher) |![stars](https://img.shields.io/github/stars/shini4i/argo-watcher)|
@@ -92,32 +77,31 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |12| Modus |[Modus is a language for building Docker/OCI container images.](https://github.com/modus-continens/modus) |![stars](https://img.shields.io/github/stars/modus-continens/modus)|
 
 ## Image Utilties
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Bing Daily Images -|[A docker container that downloads bing daily images for you](https://github.com/ms-jpq/bing-daily-images) | ![stars](https://img.shields.io/github/stars/ms-jpq/bing-daily-images)|
 
-
-
 ## Dockerfile Tools & Metrics
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Haskell Dockerfile Linter| [Dockerfile linter, validate inline bash, written in Haskell](https://github.com/hadolint/hadolint) |![stars](https://img.shields.io/github/stars/hadolint/hadolint)|
 |2| ctop | [Top-like interface for container metrics](https://github.com/bcicen/ctop) | ![stars](https://img.shields.io/github/stars/bcicen/ctop)|
 |3| Dfimage | [Reverse-engineers a Dockerfile from a Docker image.](https://github.com/LanikSJ/dfimage) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) |![stars](https://img.shields.io/github/stars/LanikSJ/dfimage)|
-|4| bctx | [ packing and uploading docker build contex](https://github.com/orisano/bctx)|![stars](https://img.shields.io/github/stars/orisano/bctx)|
+|4| bctx | [packing and uploading docker build contex](https://github.com/orisano/bctx)|![stars](https://img.shields.io/github/stars/orisano/bctx)|
 |5| Buildg master |[buildg is a tool to interactively debug Dockerfile based on BuildKit.](https://github.com/ktock/buildg)  |![stars](https://img.shields.io/github/stars/ktock/buildg)|
 
-
-
 ## Debugger
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Gebug | [A tool that makes debugging of Dockerized Go applications super easy by enabling Debugger and Hot-Reload features, seamlessly](https://github.com/moshebe/gebug) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) |![stars](https://img.shields.io/github/stars/moshebe/gebug)|
 |2| Sidekick | [Sidekick is a live application debugger that lets you troubleshoot your applications while they keep on running.](https://github.com/runsidekick/sidekick) |![stars](https://img.shields.io/github/stars/runsidekick/sidekick) |
 
-
 ## Image Security
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| TerraScan | [Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure](https://github.com/accurics/terrascan)  |![stars](https://img.shields.io/github/stars/accurics/terrascan)|
 |2| Clair | [Vulnerability Static Analysis for Containers](https://github.com/quay/clair) |![stars](https://img.shields.io/github/stars/quay/clair) |
@@ -126,25 +110,27 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |5| DockerScan | [A Docker analysis & hacking tools](https://github.com/cr0hn/dockerscan)  |![stars](https://img.shields.io/github/stars/cr0hn/dockerscan)|
 |6| Container-diff | [container-diff is a tool for analyzing and comparing container images. container-diff can examine images along several different criteria.](https://github.com/GoogleContainerTools/container-diff) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) |![stars](https://img.shields.io/github/stars/GoogleContainerTools/container-diff) |
 |7|SecretScanner| [🔓 🔓 Find secrets and passwords in container images and file systems 🔓 🔓](https://github.com/deepfence/SecretScanner)  |![stars](https://img.shields.io/github/stars/deepfence/SecretScanner)|
-|8| TerraScan | [Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure](https://github.com/accurics/terrascan) | ![stars](https://img.shields.io/github/stars/accurics/terrascan)<br>
+|8| TerraScan | [Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure](https://github.com/accurics/terrascan) | ![stars](https://img.shields.io/github/stars/accurics/terrascan)
 
 ## Docker CLI
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Docker Buildx | [A CLI plugin that extends the docker command with the full support of the features provided by Moby BuildKit builder toolkit.](https://docs.docker.com/buildx/working-with-buildx/) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564)|![stars](https://img.shields.io/github/stars/docker/docs) |
 |2| Regi | [Regi is a CLI tool for managing your accessibility to multiple Docker registries.](https://github.com/iamharvey/regi) |![stars](https://img.shields.io/github/stars/iamharvey/regi)|
 |3| Lazy Docker | [A simple terminal UI for both docker and docker-compose, written in Go with the gocui library.](https://github.com/jesseduffield/lazydocker)![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564)|![stars](https://img.shields.io/github/stars/jesseduffield/lazydocker) |
 |4| Kitt | [Kitt is a container based portable shell environment.](https://github.com/senges/kitt) |![stars](https://img.shields.io/github/stars/senges/kitt)|
-|5| Dredge | [A Docker Registry Client CLI](https://github.com/mthalman/dredge) |![stars](https://img.shields.io/github/stars/mthalman/dredge)
-
+|5| Dredge | [A Docker Registry Client CLI](https://github.com/mthalman/dredge) |![stars](https://img.shields.io/github/stars/mthalman/dredge) |
 
 ## DockerHub
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1|  DockerHub Scraper | [Scraping DockerHub](https://github.com/itamarhaber/dockerhub-scraper) |![stars](https://img.shields.io/github/stars/itamarhaber/dockerhub-scraper) |
 
 ## Deployment Tool
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Fleetform | [A tool to apply docker container infrastructure as code in a very simple human readable way](https://github.com/majo418/fleetform) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) |![stars](https://img.shields.io/github/stars/majo418/fleetform)|
 |2| Swarmsible |[Simple Ansible based Tooling for setting up and managing a production grade Docker Swarm on Ubuntu 18.04/20.04.](https://github.com/neuroforgede/swarmsible) |![stars](https://img.shields.io/github/stars/neuroforgede/swarmsible)|
@@ -152,21 +138,22 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |4| TravisCI |[Travis CI is a hosted continuous integration service used to build and test software projects hosted on GitHub, Bitbucket, GitLab, Perforce, Apache Subversion, and Assembla](https://travis-ci.org/) |![stars](https://img.shields.io/github/stars/travis-ci/travis-ci)|
 |5| CircleCI | [CircleCI has impeccable speed and is among the best CI tools. Its fast pipelines will help accelerate your business](https://circleci.com/docs/) |![stars](https://img.shields.io/github/stars/circleci)|
 
-
 ## Docker Volume
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Flocker | [Data Volume Manager for your Dockerized applications.](https://github.com/ClusterHQ/flocker)| ![stars](https://img.shields.io/github/stars/clusterhq/flocker)|
 |2| offen/docker-volume-backup | [Backup Docker volumes locally or to any S3 or WebDAV compatible storage](https://github.com/offen/docker-volume-backup)|![stars](https://img.shields.io/github/stars/offen/docker-volume-backup)|
 
 ## Cloud-Job
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Launcha | [Launcha is a docker-based cloud job launcher.](https://github.com/vwxyzjn/launcha)|![stars](https://img.shields.io/github/stars/vwxyzjn/launcha)|
 
- 
 ## Runtime Security
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1|Tracee | [Linux Runtime Security and Forensics using eBPF](https://github.com/aquasecurity/tracee) | ![stars](https://img.shields.io/github/stars/tracee)|
 |2| CetusGuard | [Tool that allows to protect the Docker daemon socket by filtering the calls to its API endpoints](https://github.com/hectorm/cetusguard)| ![stars](https://img.shields.io/github/stars/hectorm/cetusguard)|
@@ -174,7 +161,8 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |4| Falco | [Runtime security and threat detection project](https://falco.org/)![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564)| ![stars](https://img.shields.io/github/stars/cilium/tetragon)|
 
 ## Container Orchestration
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Miniboss | [Manages container locally](https://github.com/afroisalreadyinu/miniboss)| ![GitHub Stars](https://img.shields.io/github/stars/afroisalreadyinu/miniboss)|
 |2| Portainer | [Making Docker management easy. https://www.portainer.io](https://github.com/portainer/portainer)|![Docker Pulls](https://img.shields.io/docker/pulls/portainer/portainer) ![GitHub Stars](https://img.shields.io/github/stars/portainer/portainer) |
@@ -186,31 +174,35 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |8| Docker Context | [Makes it easy to switch between multiple Docker and Kubernetes environments.](https://docs.docker.com/engine/context/working-with-contexts/)| ![Github stars](https://img.shields.io/github/stars/docker/docs)  |
 |9| luet | [Container-based Package manager](https://github.com/mudler/luet) |![GitHub Stars](https://img.shields.io/github/stars/mudler/luet) |
 
-## Browser 
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+## Browser
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| kde-in-docker | [Run KDE inside a browser](https://github.com/ms-jpq/kde-in-docker) |![GitHub Stars](https://img.shields.io/github/stars/ms-jpq/kde-in-docker) |
 |2|  Portus | [3D Docker containers viewer built with Electron, React and Three Fiber](https://github.com/trindadematheus/portus)| ![GitHub Stars](https://img.shields.io/github/stars/trindadematheus/portus) <br>
 |3| snek | [Snek simplifies the process of porting software to multiple platforms. Uses @docker 20.10.12+](https://t.co/GPblsl9hRc)|![GitHub Stars](https://img.shields.io/github/stars/mcandre/snek) |
 
-
 ## Cluster Management
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Nebula | [Designed to manage massive clusters at scale.](http://nebula.readthedocs.io/en/latest/)|![GitHub Stars](https://img.shields.io/github/stars/nebula-orchestrator/docs) |
 
 ## Machine Learning
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Paddle Serving | [A flexible, high-performance carrier for machine learning models](https://github.com/PaddlePaddle/Serving) |![GitHub Stars](https://img.shields.io/github/stars/PaddlePaddle/Serving)|
 
 ## Android app
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Android-Docker | [A Docker image for building and testing Android apps.](https://github.com/randr0id/android-docker) |![GitHub Stars](https://img.shields.io/github/stars/randr0id/android-docker) |
 
 ## Development Tool
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| envd | [Development environment for AI/ML based on buildkit](https://github.com/tensorchord/envd) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564)| ![GitHub Stars](https://img.shields.io/github/stars/tensorchord/envd) |
 |2| Konveyor Move2Kube | [Automatically create Dockerfiles, Kubernetes Yamls, Helm charts and other Infrastructure as Code Artifacts for your application.](https://move2kube.konveyor.io/)| ![GitHub Stars](https://img.shields.io/github/stars/konveyor/move2kube-operator) |
@@ -220,22 +212,23 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 |6| PHPQA | [Docker image that provides static analysis tools for PHP](https://github.com/jakzal/phpqa) |![stars](https://img.shields.io/github/stars/jakzal/phpqa) |
 |7| Jump | [Jump is yet another self-hosted startpage for your server designed to be simple, stylish, fast and secure.](https://github.com/daledavies/jump) |![stars](https://img.shields.io/github/stars/daledavies/jump)|
 
-
-
 ## Workflow
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| An open source, general-purpose policy engine. | [A Docker-inspired workflow for OPA policies](https://www.openpolicyagent.org/)|![stars](https://img.shields.io/github/stars/open-policy-agent/opa)|
 
 ## Networking
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Project Calico | [Docker libnetwork plugin for Calico http://www.projectcalico.org](https://github.com/projectcalico/calico)| ![stars](https://img.shields.io/github/stars/projectcalico/calico) |
 |2| Libnetwork | [Networking for containers](https://github.com/moby/libnetwork)|![stars](https://img.shields.io/github/stars/moby/libnetwork)|
 |3| Caddy Gen | [Automated Caddy reverse proxy for docker containers](https://github.com/wemake-services/caddy-gen)|![stars](https://img.shields.io/github/stars/wemake-services/caddy-gen)|
 
 ## Swarm
-|	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
+
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
 | ---------- | --------------------- | --------------------- | ------------------ |
 |1| Orbiter | [Autoscaler for Docker Swarm](https://github.com/gianarb/orbiter)| ![stars](https://img.shields.io/github/stars/gianarb/orbiter)|
 
@@ -246,5 +239,5 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 - [Adesoji Alu](https://www.linkedin.com/in/alu/)
 
 ## Contributor
-- [Mansi Mishra](https://github.com/0904-mansi)
 
+- [Mansi Mishra](https://github.com/0904-mansi)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 ## Testing Tools
 
-- Kurtosis - [Kurtosis is a composable build system for reproducible test environments](https://github.com/kurtosis-tech/kurtosis#readmev) ![stars](https://img.shields.io/github/stars/kurtosis-tech/kurtosis) ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) ![Twitter](https://img.shields.io/twitter/follow/kurtosis-tech?style=social)
+| Serial No | Tool Name |  Description with URL | GitHub Popularity |
+| ---------- | --------------------- | --------------------- | ------------------ |
+|1| Kurtosis| - [Kurtosis is a composable build system for reproducible test environments](https://github.com/kurtosis-tech/kurtosis#readmev)![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) ![Twitter](https://img.shields.io/twitter/follow/kurtosis-tech?style=social)| ![stars](https://img.shields.io/github/stars/kurtosis-tech/kurtosis) |
 
 ## Dockerfile Tools & Metrics
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Have Questions? Join us over [Slack](https://launchpass.com/collabnix) and get c
 
 |	Serial No	|	Tool Name	|		Description with URL	|	GitHub Popularity	|
 | ---------- | --------------------- | --------------------- | ------------------ |
-| 1 | docker build  | [Easily create and share portable Docker container images using open standards](https://docs.docker.com/engine/reference/commandline/build/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs) |
-| 2 | docker buildx | [Extended build capabilities with Buildkit](https://docs.docker.com/engine/reference/commandline/buildx/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs) |
+|	1	| docker build  | [Easily create and share portable Docker container images using open standards](https://docs.docker.com/engine/reference/commandline/build/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs)     |
+|	2	|  docker buildx | [Extended build capabilities with Buildkit](https://docs.docker.com/engine/reference/commandline/buildx/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs) |
 | 3 | docker compose | [Build and Manage multiple services in Docker containers](https://docs.docker.com/engine/reference/commandline/compose/)| ![Github Stars](https://img.shields.io/github/stars/docker/docs)|
 | 4|docker scan | [Quickly detect and learn how to remediate CVEs in your Docker image](https://docs.docker.com/engine/scan/) | ![Github Stars](https://img.shields.io/github/stars/docker/docs)|
 | 5| docker context ![badge](https://camo.githubusercontent.com/3df8afcf8230a643042ceb57dc0c9e55a2fe2a126be6a7d57e38996e4d5aaa42/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d6e65772d726564) |  [Manages multiple Swarm clusters, Kubernetes clusters and Docker nodes](https://docs.docker.com/engine/context/working-with-contexts/) |![Github Stars](https://img.shields.io/github/stars/docker/docs) |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+
 ![stars](https://img.shields.io/github/stars/collabnix/dockertools)
 ![forks](https://img.shields.io/github/forks/collabnix/dockertools)
 ![issues](https://img.shields.io/github/issues/collabnix/dockertools)


### PR DESCRIPTION
I added corrator to the list of dockertools. in addition i found out there was no space between the ## Image Slim and |	Serial No which could be the reason why we have the broken display on the github page though i will still look at using  jekyll to create  html pages.